### PR TITLE
Remove references to underscore from webhook docs

### DIFF
--- a/use-rocket.chat/workspace-administration/integrations/README.md
+++ b/use-rocket.chat/workspace-administration/integrations/README.md
@@ -52,13 +52,11 @@ You can use the console methods to log information to help debug your script. Mo
 
 ```javascript
 /* exported Script */
-/* globals console, _, s */
+/* globals console */
 
 /** Global Helpers
  *
  * console - A normal console instance
- * _       - An underscore instance
- * s       - An underscore string instance
  */
 
 class Script {
@@ -180,13 +178,11 @@ The example script sends commands such as issues, comments, and pull requests to
 
 ````javascript
 /* exported Script */
-/* globals console, _, s, HTTP */
+/* globals console, HTTP */
 
 /** Global Helpers
  *
  * console - A standard console instance
- * _       - An underscore instance
- * s       - An underscore string instance
  * HTTP    - The Meteor HTTP object to do sync http calls
  */
 


### PR DESCRIPTION
I upgraded to v6 recently and it appears that underscore is no longer available as a global in webhooks. This change scrubs references to underscore for the webhook docs.