### PR TITLE
Remove unnecessarily gendered language, and fix capitalization.

### DIFF
--- a/setup-and-configure/advanced-workspace-management/restoring-an-admin.md
+++ b/setup-and-configure/advanced-workspace-management/restoring-an-admin.md
@@ -63,7 +63,7 @@ use parties
 
 To update the admin password, you can either use a one-time access token or update the admin password to a random string.
 
-Using an access token will require the user to change his password.
+Using an access token will require the user to change their password.
 
 ```javascript
 db.getCollection('users').update({username:"administrator"}, {$set: { "services":{"loginToken":{"token":"some-token-id-that-you-will-use-to-login-once"}}, "requirePasswordChange":true} })

--- a/use-rocket.chat/message-auditing/README.md
+++ b/use-rocket.chat/message-auditing/README.md
@@ -17,7 +17,7 @@ To access the **Audit Messages Panel**,
 {% hint style="info" %}
 If you can't find the audit options, don't hesitate to get in touch with your workspace administrator to [assign message auditing permissions to you](assign-message-auditing-permissions-to-specific-users.md).
 
-See [**MessagE Auditing Log**](./) to learn more about the audit log history.
+See [**Message Auditing Log**](./) to learn more about the audit log history.
 {% endhint %}
 
 ## Search and Review Messages

--- a/use-rocket.chat/rocket.chat-mobile/push-notifications/push-notification-security.md
+++ b/use-rocket.chat/rocket.chat-mobile/push-notifications/push-notification-security.md
@@ -5,7 +5,7 @@
 If you are on the Enterprise plan, the Secured Push Notification sends the ID of the message rather than the entire message through a push gateway (Apple or Google). Once the ID reaches the user’s device, the message is retrieved from Rocket.Chat server and the notification is created.
 
 {% hint style="info" %}
-This process works for both situations if the user uses Rocket.Chat’s push gateway or his own.
+This process works for both situations if the user uses Rocket.Chat’s push gateway or their own.
 {% endhint %}
 
 ## Privacy

--- a/use-rocket.chat/user-guides/messages/off-the-record-otr-messaging-user-guide.md
+++ b/use-rocket.chat/user-guides/messages/off-the-record-otr-messaging-user-guide.md
@@ -49,6 +49,6 @@ If User A or B breaks OTR (by clearing their local session storage, e.g., refres
 
 ## Ending an OTR conversation
 
-In case User A or B wants to end the OTR session, one needs to click "End OTR". This ends the OTR session. The following messages will follow the normal configuration of the DM and be recorded on the server again. Refreshing his local session storage will make all **OTR messages disappear for the user.**
+In case User A or B wants to end the OTR session, one needs to click "End OTR". This ends the OTR session. The following messages will follow the normal configuration of the DM and be recorded on the server again. Refreshing their local session storage will make all **OTR messages disappear for the user.**
 
 ![Ending OTR conversations](<../../../.gitbook/assets/image (1245).png>)

--- a/use-rocket.chat/workspace-administration/settings/federation/matrix-bridge/matrix-users-guide/assign-roles-for-users-in-federated-rooms.md
+++ b/use-rocket.chat/workspace-administration/settings/federation/matrix-bridge/matrix-users-guide/assign-roles-for-users-in-federated-rooms.md
@@ -38,8 +38,8 @@ The main rules for assigning roles in federated rooms are:
 * All the users added to federated rooms have a User role by default.
 * Users with the same role cannot assign roles (promote/demote) between them.
 * Users with a specific role cannot demote other users from the room with the same role.
-* Users can only demote and promote users in the layer again right below his/her roles.
-* Whenever a user wants to promote a user to a role as powerful as his/her own, undoing that change will not be possible (a confirmation modal will double-check the operation).
+* Users can only demote and promote users in the layer again right below their roles.
+* Whenever a user wants to promote a user to a role as powerful as their own, undoing that change will not be possible (a confirmation modal will double-check the operation).
 * Whenever a user wants to demote himself/herself, it will not be possible to regain the same privileges the user has had. The only possibility is for a user with the necessary permission to give back the same role for that user(a confirmation modal will double-check the operation).
 
 For any other applicable rule, they are the same as regular Rocket.Chat rooms (e.g., Room owners cannot demote themselves if they are the last room owner).


### PR DESCRIPTION
Two changes here, first is a change made to the language used in the Advanced Workspace Management section(among other places) of the docs to make a needlessly gendered message more neutral. 
The second change is fixing a capitalization error in the Message Auditing section of the docs.