### PR TITLE
Update Caddyfile example

### DIFF
--- a/setup-and-configure/environment-configuration/configuring-ssl-reverse-proxy.md
+++ b/setup-and-configure/environment-configuration/configuring-ssl-reverse-proxy.md
@@ -164,8 +164,5 @@ Insert
 ```
 yourdomain.com {
         reverse_proxy localhost:3000
-        header Access-Control-Allow-Methods "POST, GET, OPTIONS"
-        header Access-Control-Allow-Headers "*"
-        import cors https://sub.domain.livechat
 }
 ```


### PR DESCRIPTION
Context: https://caddy.community/t/inserting-rocket-chat-into-caddyfile-correctly/23063/15

These lines don't make sense; CORS headers shouldn't be needed. And `import` does not work unless a [snippet](https://caddyserver.com/docs/caddyfile/concepts#snippets) is declared first.