### PR TITLE
Fix: Updated mongodb shell commands to use 'mongosh' instead of deprecated 'mongo'

### DIFF
--- a/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-on-debian.md
+++ b/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-on-debian.md
@@ -195,7 +195,7 @@ sudo systemctl enable --now mongod
 * Then, initiate replica set with this command:
 
 ```bash
-mongo --eval "printjson(rs.initiate())"
+mongosh --eval "printjson(rs.initiate())"
 ```
 
 * You can start your Rocket.Chat workspace now using this command:

--- a/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-on-kali.md
+++ b/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-on-kali.md
@@ -133,7 +133,7 @@ sudo systemctl enable mongod && sudo systemctl start mongod
 * Then, initiate replica set with this command:
 
 ```bash
-mongo --eval "printjson(rs.initiate())"
+mongosh --eval "printjson(rs.initiate())"
 ```
 
 * Enable and start your Rocket.Chat workspace now using this command:

--- a/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-with-centos.md
+++ b/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-with-centos.md
@@ -114,7 +114,7 @@ sudo systemctl enable mongod && sudo systemctl start mongod
 ```
 
 ```
-mongo --eval "printjson(rs.initiate())"
+mongosh --eval "printjson(rs.initiate())"
 ```
 
 * Enable and start Rocket.Chat using this command:

--- a/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-with-ubuntu.md
+++ b/deploy/deploy-rocket.chat/additional-deployment-methods/deploy-with-ubuntu.md
@@ -174,7 +174,7 @@ sudo systemctl enable --now mongod
 * Then, initiate  replica set with this command:
 
 ```bash
-mongo --eval "printjson(rs.initiate())"
+mongosh --eval "printjson(rs.initiate())"
 ```
 
 * You can start your Rocket.Chat workspace now using this command:

--- a/deploy/deploy-rocket.chat/additional-deployment-methods/unsupported-methods/opensuse-leap-42.2.md
+++ b/deploy/deploy-rocket.chat/additional-deployment-methods/unsupported-methods/opensuse-leap-42.2.md
@@ -104,7 +104,7 @@ systemctl start mongodb
 Now start a MongoDB shell and add the admin user:
 
 ```
-> mongo
+> mongosh
 use admin
 
 db.createUser({

--- a/deploy/deploy-rocket.chat/scaling-rocket.chat/automation-tools/openshift.md
+++ b/deploy/deploy-rocket.chat/scaling-rocket.chat/automation-tools/openshift.md
@@ -40,7 +40,7 @@ oc new-app rocket-chat -p MONGODB_DATABASE=rocketchat,MONGODB_USER=rocketchat-ad
 
 ```bash
 oc port-forward <mongodb_pod> 27017
-mongo localhost:27017
+mongosh localhost:27017
 ```
 
 Inside the mongo client, run these commands:

--- a/setup-and-configure/environment-configuration/mongodb-configuration/configure-a-replica-set-for-mongodb.md
+++ b/setup-and-configure/environment-configuration/mongodb-configuration/configure-a-replica-set-for-mongodb.md
@@ -32,7 +32,7 @@ sudo systemctl restart mongod
 2. Start the MongoDB shell and initiate the replica set:
 
 ```bash
-mongo
+mongosh
 > rs.initiate()
 ```
 

--- a/setup-and-configure/environment-configuration/mongodb-configuration/migrate-from-mmap-to-wiredtiger-storage-engine.md
+++ b/setup-and-configure/environment-configuration/mongodb-configuration/migrate-from-mmap-to-wiredtiger-storage-engine.md
@@ -61,7 +61,7 @@ Here are the detailed steps of the migration process:
 7.  If running with a Replica-Set in your mongo.conf initialize replica set
 
     ```bash
-    mongo --eval 'rs.initiate()'
+    mongosh --eval 'rs.initiate()'
     ```
 8.  Import dump back into (_wiredTiger_) MongoDB:
 
@@ -71,7 +71,7 @@ Here are the detailed steps of the migration process:
 9.  Repair databases and rebuild indices:
 
     ```bash
-    mongo --eval 'db.repairDatabase()'
+    mongosh --eval 'db.repairDatabase()'
     ```
 10. Start Rocket.Chat service:
 


### PR DESCRIPTION
[ Related issue ](https://github.com/RocketChat/docs/issues/4#issuecomment-2093157904)

[ The 'mongo' CLI is deprecated](https://www.mongodb.com/docs/v6.0/reference/mongo/)